### PR TITLE
Add new error types and handle some nonconformant files.

### DIFF
--- a/src/error.rs
+++ b/src/error.rs
@@ -8,14 +8,44 @@ pub enum ASEError {
     /// An error was encountered while parsing the ASE.
     ///
     /// This means that the input data did not conform to the ASE specification.
-    Invalid,
+    Invalid(ConformationError),
+    /// An error occured due to slice conversion issues.
+    SliceError,
+    /// An erorr occured due to Utf16 parsing issues.
+    UTF16Error,
+    /// An error occured due to an invalid color type.
+    ColorTypeError,
+    /// An error occured due to an invalid block type.
+    BlockTypeError,
+}
+
+#[derive(Debug)]
+pub enum ConformationError {
+    FileVersion,
+    FileSignature,
+    GroupEnd,
 }
 
 impl Display for ASEError {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        match self {
+        let var_name = match self {
             ASEError::Io(err) => err.fmt(f),
-            ASEError::Invalid => write!(f, "ASE file is invalid"),
+            ASEError::Invalid(err) => write!(f, "ASE file is invalid: {err}"),
+            ASEError::SliceError => write!(f, "Error converting input slice"),
+            ASEError::UTF16Error => write!(f, "Error converting UTF16"),
+            ASEError::ColorTypeError => write!(f, "Error converting ColorType"),
+            ASEError::BlockTypeError => write!(f, "Error converting BlockType"),
+        };
+        var_name
+    }
+}
+
+impl Display for ConformationError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            ConformationError::FileVersion => write!(f, "File version is not supported"),
+            ConformationError::FileSignature => write!(f, "Invalid file signature found"),
+            ConformationError::GroupEnd => write!(f, "Blocks must end to be valid"),
         }
     }
 }
@@ -30,12 +60,12 @@ impl From<io::Error> for ASEError {
 
 impl From<array::TryFromSliceError> for ASEError {
     fn from(_value: array::TryFromSliceError) -> Self {
-        ASEError::Invalid
+        ASEError::SliceError
     }
 }
 
 impl From<string::FromUtf16Error> for ASEError {
     fn from(_value: string::FromUtf16Error) -> Self {
-        ASEError::Invalid
+        ASEError::UTF16Error
     }
 }

--- a/src/types/block_type.rs
+++ b/src/types/block_type.rs
@@ -19,7 +19,7 @@ impl TryFrom<u16> for BlockType {
             0x0001 => Ok(Self::ColorEntry),
             0xc001 => Ok(Self::GroupStart),
             0xc002 => Ok(Self::GroupEnd),
-            _ => Err(ASEError::Invalid),
+            _ => Err(ASEError::BlockTypeError),
         }
     }
 }

--- a/src/types/color_type.rs
+++ b/src/types/color_type.rs
@@ -37,7 +37,7 @@ impl TryFrom<&u8> for ColorType {
             0 => Ok(ColorType::Global),
             1 => Ok(ColorType::Spot),
             2 => Ok(ColorType::Normal),
-            _ => Err(ASEError::Invalid),
+            _ => Err(ASEError::ColorTypeError),
         }
     }
 }

--- a/src/types/color_value.rs
+++ b/src/types/color_value.rs
@@ -83,7 +83,7 @@ impl TryFrom<&[u8]> for ColorValue {
             b"Gray" => Ok(ColorValue::Gray(f32::from_be_bytes(
                 value[4..8].try_into()?,
             ))),
-            _ => Err(ASEError::Invalid),
+            _ => Err(ASEError::SliceError),
         }
     }
 }

--- a/src/types/group.rs
+++ b/src/types/group.rs
@@ -3,7 +3,7 @@ use crate::{buffer::Buffer, error::ASEError};
 use super::{block_type::BlockType, ColorBlock};
 
 ///Represents a named collection of colors
-#[derive(Debug, Clone, PartialEq)]
+#[derive(Debug, Clone, PartialEq, Default)]
 pub struct Group {
     /// The name of the group
     pub name: String,

--- a/src/types/mod.rs
+++ b/src/types/mod.rs
@@ -16,3 +16,9 @@ pub(crate) const FILE_SIGNATURE: &[u8; 4] = b"ASEF";
 
 /// Version of the ASE file.
 pub(crate) const VERSION: u32 = 0x00010000;
+
+#[derive(Debug, PartialEq)]
+pub(crate) enum GroupHold {
+    Holding,
+    Empty,
+}


### PR DESCRIPTION
New Error Types: Updated errors for certain situations where the Invalid file error was being throw, this clarifies the cause of the error.

Handle some less conformant files: Many files in the wild features group blocks which are not fully parsed together, when this occurs they will incorectly be interpreted as empty. The change fixes this behavior when the group block is not parsed together.

I have attached a zip file containing "in the wild" examples of this behavior.

[DIGITAL COLOR SWATCHES for Adobe.zip](https://github.com/FineFindus/adobe-swatch-exchange-rs/files/13729529/DIGITAL.COLOR.SWATCHES.for.Adobe.zip)
