### PR TITLE
Enhanced errors

### DIFF
--- a/src/error.rs
+++ b/src/error.rs
@@ -23,10 +23,18 @@ pub enum ASEError {
     InputDataParseError,
 }
 
+/// Indicates the cause of the file being an invalid ase.
 #[derive(Debug)]
 pub enum ConformationError {
+    /// An invalid file version was detected.
+    ///
+    /// Currently on a version of 1.0 is supported.
     FileVersion,
+    /// An invalid file signature was detected.
+    ///
+    /// The file signature must be 'ASEF'.
     FileSignature,
+    /// Groups must be terminated with a GroupEnd block.
     GroupEnd,
 }
 

--- a/src/error.rs
+++ b/src/error.rs
@@ -8,14 +8,48 @@ pub enum ASEError {
     /// An error was encountered while parsing the ASE.
     ///
     /// This means that the input data did not conform to the ASE specification.
-    Invalid,
+    Invalid(ConformationError),
+    /// An error occured due to an invalid color format.
+    ///
+    /// Valid color formats are: CMYK, RGB, LAB, Gray.
+    ColorFormat,
+    /// An error occured due to Utf16 parsing issues.
+    UTF16Error,
+    /// An error occured due to an invalid color type.
+    ColorTypeError,
+    /// An error occured due to an invalid block type.
+    BlockTypeError,
+    /// An error occured while parsing the input data.
+    InputDataParseError,
+}
+
+#[derive(Debug)]
+pub enum ConformationError {
+    FileVersion,
+    FileSignature,
+    GroupEnd,
 }
 
 impl Display for ASEError {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         match self {
             ASEError::Io(err) => err.fmt(f),
-            ASEError::Invalid => write!(f, "ASE file is invalid"),
+            ASEError::Invalid(err) => write!(f, "ASE file is invalid: {err}"),
+            ASEError::ColorFormat => write!(f, "Error parsing color format"),
+            ASEError::UTF16Error => write!(f, "Error converting UTF16"),
+            ASEError::ColorTypeError => write!(f, "Error converting ColorType"),
+            ASEError::BlockTypeError => write!(f, "Error converting BlockType"),
+            ASEError::InputDataParseError => write!(f, "Error parsing input data"),
+        }
+    }
+}
+
+impl Display for ConformationError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            ConformationError::FileVersion => write!(f, "File version is not supported"),
+            ConformationError::FileSignature => write!(f, "Invalid file signature found"),
+            ConformationError::GroupEnd => write!(f, "Blocks must end to be valid"),
         }
     }
 }
@@ -30,12 +64,12 @@ impl From<io::Error> for ASEError {
 
 impl From<array::TryFromSliceError> for ASEError {
     fn from(_value: array::TryFromSliceError) -> Self {
-        ASEError::Invalid
+        ASEError::InputDataParseError
     }
 }
 
 impl From<string::FromUtf16Error> for ASEError {
     fn from(_value: string::FromUtf16Error) -> Self {
-        ASEError::Invalid
+        ASEError::UTF16Error
     }
 }

--- a/src/error.rs
+++ b/src/error.rs
@@ -28,11 +28,11 @@ pub enum ASEError {
 pub enum ConformationError {
     /// An invalid file version was detected.
     ///
-    /// Currently on a version of 1.0 is supported.
+    /// Currently only version `1.0`` of the format exists.
     FileVersion,
     /// An invalid file signature was detected.
     ///
-    /// The file signature must be 'ASEF'.
+    /// The file signature must be `ASEF`.
     FileSignature,
     /// Groups must be terminated with a GroupEnd block.
     GroupEnd,

--- a/src/error.rs
+++ b/src/error.rs
@@ -28,7 +28,7 @@ pub enum ASEError {
 pub enum ConformationError {
     /// An invalid file version was detected.
     ///
-    /// Currently only version `1.0`` of the format exists.
+    /// Currently only version `1.0` of the format exists.
     FileVersion,
     /// An invalid file signature was detected.
     ///

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -60,13 +60,13 @@ pub fn read_ase<T: std::io::Read>(mut ase: T) -> Result<(Vec<Group>, Vec<ColorBl
     //read magic bytes
     ase.read_exact(&mut buf_u32)?;
     if &buf_u32 != types::FILE_SIGNATURE {
-        return Err(ASEError::Invalid);
+        return Err(ASEError::Invalid(error::ConformationError::FileSignature));
     }
 
     //read version,should be 1.0
     ase.read_exact(&mut buf_u32)?;
     if buf_u32 != types::VERSION.to_be_bytes() {
-        return Err(ASEError::Invalid);
+        return Err(ASEError::Invalid(error::ConformationError::FileVersion));
     }
 
     ase.read_exact(&mut buf_u32)?;
@@ -96,7 +96,7 @@ pub fn read_ase<T: std::io::Read>(mut ase: T) -> Result<(Vec<Group>, Vec<ColorBl
                 ase.read_exact(&mut buf_u16)?;
                 if BlockType::try_from(u16::from_be_bytes(buf_u16))? != BlockType::GroupEnd {
                     // group has no end, file is invalid
-                    return Err(ASEError::Invalid);
+                    return Err(ASEError::Invalid(error::ConformationError::GroupEnd));
                 }
             }
             //read by the group end

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,7 +1,7 @@
 #![deny(rustdoc::broken_intra_doc_links)]
 #![deny(unsafe_code)]
 #![doc = include_str!("../README.md")]
-pub use error::ASEError;
+pub use error::{ASEError, ConformationError};
 use types::BlockType;
 pub use types::{ColorBlock, ColorType, ColorValue, Group};
 

--- a/src/types/block_type.rs
+++ b/src/types/block_type.rs
@@ -19,7 +19,7 @@ impl TryFrom<u16> for BlockType {
             0x0001 => Ok(Self::ColorEntry),
             0xc001 => Ok(Self::GroupStart),
             0xc002 => Ok(Self::GroupEnd),
-            _ => Err(ASEError::Invalid),
+            _ => Err(ASEError::BlockTypeError),
         }
     }
 }

--- a/src/types/color_type.rs
+++ b/src/types/color_type.rs
@@ -37,7 +37,7 @@ impl TryFrom<&u8> for ColorType {
             0 => Ok(ColorType::Global),
             1 => Ok(ColorType::Spot),
             2 => Ok(ColorType::Normal),
-            _ => Err(ASEError::Invalid),
+            _ => Err(ASEError::ColorTypeError),
         }
     }
 }

--- a/src/types/color_value.rs
+++ b/src/types/color_value.rs
@@ -83,7 +83,7 @@ impl TryFrom<&[u8]> for ColorValue {
             b"Gray" => Ok(ColorValue::Gray(f32::from_be_bytes(
                 value[4..8].try_into()?,
             ))),
-            _ => Err(ASEError::Invalid),
+            _ => Err(ASEError::ColorFormat),
         }
     }
 }


### PR DESCRIPTION
Adds new error types to describe the cause of a failed parse attempt in detail. New tests have also been added to verify that those errors are being returned correctly.

This is a potentially breaking change for any user that directly interacts with the ASError type.

This replaces the first half of pull request #1 